### PR TITLE
Wrap editor usernames in backticks to prevent @mentions

### DIFF
--- a/src/__tests__/reviewerComment.test.ts
+++ b/src/__tests__/reviewerComment.test.ts
@@ -1,0 +1,108 @@
+import {
+    FileRuleCommentData,
+    generateReviewerComment,
+} from "../reviewerComment";
+
+describe("generateReviewerComment", () => {
+    it("wraps editor reviewers in backticks to suppress pings", () => {
+        const filesToRules: { [key: string]: FileRuleCommentData[] } = {
+            "EIPS/eip-1.md": [
+                {
+                    min: 2,
+                    requesting: ["lightclient", "samwilsn", "g11tech"],
+                    mention_reviewers: false,
+                },
+            ],
+        };
+
+        const comment = generateReviewerComment(filesToRules);
+        expect(comment).toContain(
+            "Requires 2 more reviewers from `@g11tech`, `@lightclient`, `@samwilsn`",
+        );
+    });
+
+    it("keeps real @mentions for author reviewers", () => {
+        const filesToRules: { [key: string]: FileRuleCommentData[] } = {
+            "EIPS/eip-1.md": [
+                {
+                    min: 1,
+                    requesting: ["vitalik"],
+                    mention_reviewers: true,
+                },
+                {
+                    min: 2,
+                    requesting: ["lightclient", "samwilsn", "g11tech"],
+                    mention_reviewers: false,
+                },
+            ],
+        };
+
+        const comment = generateReviewerComment(filesToRules);
+        expect(comment).toContain("Requires 1 more reviewers from @vitalik");
+        expect(comment).toContain(
+            "Requires 2 more reviewers from `@g11tech`, `@lightclient`, `@samwilsn`",
+        );
+    });
+
+    it("pings an editor as an author when they authored the EIP", () => {
+        const filesToRules: { [key: string]: FileRuleCommentData[] } = {
+            "EIPS/eip-1.md": [
+                {
+                    min: 1,
+                    requesting: ["samwilsn"],
+                    mention_reviewers: true,
+                },
+                {
+                    min: 2,
+                    requesting: ["lightclient", "samwilsn", "g11tech"],
+                    mention_reviewers: false,
+                },
+            ],
+        };
+
+        const comment = generateReviewerComment(filesToRules);
+        expect(comment).toContain("Requires 1 more reviewers from @samwilsn");
+        expect(comment).toContain(
+            "Requires 2 more reviewers from `@g11tech`, `@lightclient`, `@samwilsn`",
+        );
+    });
+
+    it("dedupes rules with the same reviewers and keeps the first", () => {
+        const filesToRules: { [key: string]: FileRuleCommentData[] } = {
+            "EIPS/eip-1.md": [
+                {
+                    min: 1,
+                    requesting: ["bob", "alice"],
+                    mention_reviewers: false,
+                },
+                {
+                    min: 2,
+                    requesting: ["alice", "bob"],
+                    mention_reviewers: false,
+                },
+            ],
+        };
+
+        const comment = generateReviewerComment(filesToRules);
+        expect(comment.match(/Requires/g)?.length).toBe(1);
+        expect(comment).toContain(
+            "Requires 1 more reviewers from `@alice`, `@bob`",
+        );
+    });
+
+    it("does not mutate requesting reviewer arrays", () => {
+        const requesting = ["bob", "alice"];
+        const filesToRules: { [key: string]: FileRuleCommentData[] } = {
+            "EIPS/eip-1.md": [
+                {
+                    min: 1,
+                    requesting,
+                    mention_reviewers: false,
+                },
+            ],
+        };
+
+        generateReviewerComment(filesToRules);
+        expect(requesting).toEqual(["bob", "alice"]);
+    });
+});

--- a/src/__tests__/reviewerComment.test.ts
+++ b/src/__tests__/reviewerComment.test.ts
@@ -105,4 +105,26 @@ describe("generateReviewerComment", () => {
         generateReviewerComment(filesToRules);
         expect(requesting).toEqual(["bob", "alice"]);
     });
+
+    it("collapses duplicate reviewer sets and prefers ping format", () => {
+        const filesToRules: { [key: string]: FileRuleCommentData[] } = {
+            "EIPS/eip-1.md": [
+                {
+                    min: 1,
+                    requesting: ["samwilsn"],
+                    mention_reviewers: false,
+                },
+                {
+                    min: 1,
+                    requesting: ["samwilsn"],
+                    mention_reviewers: true,
+                },
+            ],
+        };
+
+        const comment = generateReviewerComment(filesToRules);
+        expect(comment.match(/Requires/g)?.length).toBe(1);
+        expect(comment).toContain("Requires 1 more reviewers from @samwilsn");
+        expect(comment).not.toContain("`@samwilsn`");
+    });
 });

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,5 +1,9 @@
 import { performMergeAction, preMergeChanges } from "./merge.js";
 import processFiles from "./process.js";
+import {
+    FileRuleCommentData,
+    generateReviewerComment,
+} from "./reviewerComment.js";
 import { File, RuleProcessed } from "./types.js";
 import core from "@actions/core";
 import github from "@actions/github";
@@ -536,9 +540,7 @@ async function run() {
         // Generate comment
         let comment = "";
         if (!wholePassed) {
-            const filesToRules: {
-                [key: string]: { min: number; requesting: string[] }[];
-            } = {};
+            const filesToRules: { [key: string]: FileRuleCommentData[] } = {};
             for (const rule of result) {
                 core.error(
                     `Rule ${rule.name} requires ${
@@ -554,45 +556,13 @@ async function run() {
                     filesToRules[file].push({
                         min: rule.min,
                         requesting: rule.reviewers,
+                        mention_reviewers: rule.mention_reviewers ?? false,
                     });
                 } else {
                     core.setFailed("Rule annotation must contain a file");
                 }
             }
-
-            for (const file in filesToRules) {
-                comment = `${comment}\n\n### File \`${file}\`\n\n`;
-                const pastReviewers: string[] = [];
-                for (const rule of filesToRules[file]) {
-                    for (const rule2 of filesToRules[file]) {
-                        if (
-                            !pastReviewers.includes(
-                                rule.requesting.sort().join(","),
-                            ) &&
-                            rule.requesting.sort().join(",") ===
-                                rule2.requesting.sort().join(",")
-                        ) {
-                            pastReviewers.push(
-                                rule.requesting.sort().join(","),
-                            );
-                            if (rule2.min > rule.min) {
-                                comment = `${comment}Requires ${
-                                    rule2.min
-                                } more reviewers from ${rule.requesting
-                                    .map((requesting) => `@${requesting}`)
-                                    .join(", ")}\n`;
-                            } else {
-                                comment = `${comment}Requires ${
-                                    rule.min
-                                } more reviewers from ${rule.requesting
-                                    .map((requesting) => `@${requesting}`)
-                                    .join(", ")}\n`;
-                            }
-                            break;
-                        }
-                    }
-                }
-            }
+            comment = generateReviewerComment(filesToRules);
         } else {
             comment = "✅ All reviewers have approved.";
         }

--- a/src/reviewerComment.ts
+++ b/src/reviewerComment.ts
@@ -1,0 +1,51 @@
+export type FileRuleCommentData = {
+    min: number;
+    requesting: string[];
+    mention_reviewers: boolean;
+};
+
+function buildRuleKey(
+    requesting: string[],
+    mention_reviewers: boolean,
+): string {
+    const mentionMode = mention_reviewers ? "mention" : "no-mention";
+    return `${mentionMode}:${requesting.join(",")}`;
+}
+
+function formatReviewer(username: string, mention_reviewers: boolean): string {
+    return mention_reviewers ? `@${username}` : `\`@${username}\``;
+}
+
+function summarizeRules(
+    fileRules: FileRuleCommentData[],
+): FileRuleCommentData[] {
+    const byRule = new Map<string, FileRuleCommentData>();
+    for (const rule of fileRules) {
+        const requesting = [...rule.requesting].sort();
+        const key = buildRuleKey(requesting, rule.mention_reviewers);
+        if (byRule.has(key)) {
+            continue;
+        }
+        byRule.set(key, {
+            min: rule.min,
+            requesting,
+            mention_reviewers: rule.mention_reviewers,
+        });
+    }
+    return Array.from(byRule.values());
+}
+
+export function generateReviewerComment(
+    filesToRules: Record<string, FileRuleCommentData[]>,
+): string {
+    let comment = "";
+    for (const [file, rules] of Object.entries(filesToRules)) {
+        comment = `${comment}\n\n### File \`${file}\`\n\n`;
+        for (const rule of summarizeRules(rules)) {
+            comment = `${comment}Requires ${rule.min} more reviewers from ${rule.requesting
+                .map((r) => formatReviewer(r, rule.mention_reviewers))
+                .join(", ")}\n`;
+        }
+    }
+    return comment;
+}

--- a/src/reviewerComment.ts
+++ b/src/reviewerComment.ts
@@ -4,12 +4,8 @@ export type FileRuleCommentData = {
     mention_reviewers: boolean;
 };
 
-function buildRuleKey(
-    requesting: string[],
-    mention_reviewers: boolean,
-): string {
-    const mentionMode = mention_reviewers ? "mention" : "no-mention";
-    return `${mentionMode}:${requesting.join(",")}`;
+function buildRuleKey(requesting: string[]): string {
+    return requesting.join(",");
 }
 
 function formatReviewer(username: string, mention_reviewers: boolean): string {
@@ -22,8 +18,11 @@ function summarizeRules(
     const byRule = new Map<string, FileRuleCommentData>();
     for (const rule of fileRules) {
         const requesting = [...rule.requesting].sort();
-        const key = buildRuleKey(requesting, rule.mention_reviewers);
-        if (byRule.has(key)) {
+        const key = buildRuleKey(requesting);
+        const existing = byRule.get(key);
+        if (existing) {
+            existing.mention_reviewers =
+                existing.mention_reviewers || rule.mention_reviewers;
             continue;
         }
         byRule.set(key, {

--- a/src/rules/authors.ts
+++ b/src/rules/authors.ts
@@ -40,6 +40,7 @@ export default async function (
                             reviewers: reviewers,
                             min: 1,
                             pr_approval: true,
+                            mention_reviewers: true,
                             annotation: {
                                 file: file.filename,
                             },

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,11 @@ export declare type Rule = {
     pr_approval?: boolean | undefined;
 
     /**
+     * Whether reviewers should be @mentioned in PR comments (default: false)
+     */
+    mention_reviewers?: boolean | undefined;
+
+    /**
      * The labels to add to the PR if the rule is not satisfied, or remove if the rule is satisfied
      */
     labels?: string[] | undefined;


### PR DESCRIPTION
## Summary

Fixes #426. The bot uses real GitHub `@mentions` for reviewer usernames in PR comments, which pings every editor on every PR. Since editors already monitor all PRs, these notifications are noise.

This PR adds a `mention_reviewers` flag to the `Rule` type. Rules that set `mention_reviewers: true` (currently only the `authors` rule) produce real `@mentions`. All other rules default to `false`, wrapping usernames in backticks (`` `@username` ``) to suppress notifications.

**Before:** `Requires 1 more reviewers from @editor1, @editor2`
**After:** `Requires 1 more reviewers from` `` `@editor1` ``, `` `@editor2` ``

An editor who is also an EIP author still gets a real `@mention` when they appear as an author, and a backtick-wrapped name when they appear as an editor.

## Changes

- **`src/types.ts`** — Add `mention_reviewers?: boolean` to `Rule`
- **`src/rules/authors.ts`** — Set `mention_reviewers: true`
- **`src/reviewerComment.ts`** — Extract comment-building logic from `action.ts` into a testable module
- **`src/__tests__/reviewerComment.test.ts`** — Tests for mention formatting, deduplication, and non-mutation
- **`src/action.ts`** — Use extracted `generateReviewerComment()`, pass `mention_reviewers` through

🤖 Generated with [Claude Code](https://claude.com/claude-code)
reviewed by dionysuzx and codex