### PR TITLE
Fix asset-only PR handling by fetching parent file content

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,7 @@ export default {
     transform: {
         "^.+\\.(ts|tsx)$": "ts-jest",
     },
+    moduleNameMapper: {
+        "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
 };

--- a/src/rules/__tests__/assets.test.ts
+++ b/src/rules/__tests__/assets.test.ts
@@ -1,0 +1,145 @@
+import { Octokit } from "../../types";
+import checkAssets from "../assets";
+
+jest.mock("@actions/github", () => ({
+    __esModule: true,
+    default: {
+        context: {
+            repo: {
+                owner: "ethereum",
+                repo: "EIPs",
+            },
+        },
+    },
+}));
+
+jest.mock("../../process", () => ({
+    __esModule: true,
+    default: jest.fn(
+        (
+            _o: unknown,
+            _c: unknown,
+            files: { filename: string; contents?: string }[],
+        ) =>
+            files.flatMap((f) => {
+                const authors = f.contents
+                    ?.match(/author:\s*(.+)/)?.[1]
+                    ?.match(/@(\w+)/g)
+                    ?.map((s) => s.slice(1));
+                if (!authors?.length) return [];
+                return [
+                    {
+                        name: "authors",
+                        reviewers: authors,
+                        min: 1,
+                        pr_approval: true,
+                        annotation: { file: f.filename },
+                    },
+                ];
+            }),
+    ),
+}));
+
+const frontmatter =
+    "---\nstatus: Draft\ncategory: ERC\nauthor: Alice (@alice), Bob (@bob)\n---\nHello!";
+function makeFakeOctokit() {
+    return {
+        rest: {
+            repos: {
+                getContent: jest.fn().mockResolvedValue({
+                    data: frontmatter,
+                }),
+            },
+        },
+    } as unknown as Octokit;
+}
+
+describe("checkAssets", () => {
+    test("Should require author approval for asset-only EIP changes", async () => {
+        const fakeOctokit = makeFakeOctokit();
+        const result = await checkAssets(
+            fakeOctokit,
+            { erc: ["editor1", "editor2", "editor3"] },
+            [
+                {
+                    filename: "assets/eip-1234/image.png",
+                    status: "modified",
+                },
+            ],
+        );
+        expect(result).toMatchObject([
+            {
+                name: "authors",
+                reviewers: ["alice", "bob"],
+                min: 1,
+                pr_approval: true,
+                annotation: {
+                    file: "EIPS/eip-1234.md",
+                },
+            },
+        ]);
+    });
+
+    test("Should require author approval for asset-only ERC changes", async () => {
+        const fakeOctokit = makeFakeOctokit();
+        const result = await checkAssets(
+            fakeOctokit,
+            { erc: ["editor1", "editor2", "editor3"] },
+            [
+                {
+                    filename: "assets/erc-5678/diagram.svg",
+                    status: "modified",
+                },
+            ],
+        );
+        expect(result).toMatchObject([
+            {
+                name: "authors",
+                reviewers: ["alice", "bob"],
+                min: 1,
+                pr_approval: true,
+                annotation: {
+                    file: "ERCS/erc-5678.md",
+                },
+            },
+        ]);
+    });
+
+    test("Should skip when parent EIP file is also in the PR", async () => {
+        const fakeOctokit = makeFakeOctokit();
+        const result = await checkAssets(
+            fakeOctokit,
+            { erc: ["editor1", "editor2", "editor3"] },
+            [
+                {
+                    filename: "assets/eip-1234/image.png",
+                    status: "modified",
+                },
+                {
+                    filename: "EIPS/eip-1234.md",
+                    status: "modified",
+                    contents: frontmatter,
+                    previous_contents: frontmatter,
+                },
+            ],
+        );
+        expect(result).toEqual([]);
+    });
+
+    test("Should return empty for non-asset files", async () => {
+        const fakeOctokit = makeFakeOctokit();
+        const result = await checkAssets(
+            fakeOctokit,
+            { erc: ["editor1", "editor2", "editor3"] },
+            [
+                {
+                    filename: "EIPS/eip-1234.md",
+                    status: "modified",
+                    contents: frontmatter,
+                    previous_contents: frontmatter,
+                },
+            ],
+        );
+        expect(result).toEqual([]);
+    });
+});

--- a/src/rules/assets.ts
+++ b/src/rules/assets.ts
@@ -1,5 +1,6 @@
 import processFiles from "../process.js";
 import { Config, File, Octokit, Rule } from "../types.js";
+import github from "@actions/github";
 
 export default async function (
     octokit: Octokit,
@@ -14,7 +15,7 @@ export default async function (
                 file.filename.startsWith("assets/eip-") &&
                 !files.some(
                     (f) =>
-                        f.filename == `EIPS/${file.filename.split("/")[2]}.md`,
+                        f.filename == `EIPS/${file.filename.split("/")[1]}.md`,
                 )
             ) {
                 filename = `EIPS/${file.filename.split("/")[1]}.md`;
@@ -22,7 +23,7 @@ export default async function (
                 file.filename.startsWith("assets/erc-") &&
                 !files.some(
                     (f) =>
-                        f.filename == `ERCS/${file.filename.split("/")[2]}.md`,
+                        f.filename == `ERCS/${file.filename.split("/")[1]}.md`,
                 )
             ) {
                 filename = `ERCS/${file.filename.split("/")[1]}.md`;
@@ -33,10 +34,26 @@ export default async function (
             if (files.some((file) => file.filename == filename)) {
                 return []; // Already covered by the relevant rules, so avoid potential conflicts by short circuiting
             }
+            let contents: string | undefined;
+            try {
+                contents = (
+                    await octokit.rest.repos.getContent({
+                        ...github.context.repo,
+                        path: filename,
+                        mediaType: { format: "raw" },
+                    })
+                ).data as unknown as string;
+            } catch (e) {
+                if (!(e instanceof Object && "status" in e && e.status === 404))
+                    throw e;
+            }
+
             return processFiles(octokit, config, [
                 {
                     filename,
                     status: "modified",
+                    contents,
+                    previous_contents: contents,
                 },
             ]);
         }),


### PR DESCRIPTION
Fixes #420 

## Problem

When a PR only touches asset files (e.g. `assets/eip-1234/image.png`), the bot creates a synthetic `EIPS/eip-1234.md` file to run rules against — but without fetching the actual file content. Since there's no frontmatter to parse, `checkAuthors` returns nothing and the bot falls back to a `statuschange` rule, blocking the PR and requiring editor review even when the PR author is an EIP author.

A secondary bug: `split("/")[2]` on `assets/eip-1234/image.png` gives `image.png` instead of `eip-1234`, causing the duplicate-file check to never match.

## Fix

- Fetch the parent EIP/ERC markdown from the default branch via the GitHub API so `checkAuthors` can parse authors from frontmatter
- Fix `split("/")[2]` → `split("/")[1]` to correctly extract the EIP number
- Add 4 tests + a `moduleNameMapper` fix for `.js` → `.ts` resolution in Jest

## Testing

Tested end-to-end on [dionysuzx/EIPs#5](https://github.com/dionysuzx/EIPs/pull/5) — an asset-only PR (`assets/eip-99999/test-run-5.json`) where `EIPS/eip-99999.md` lists `@dionysuzx` as author.

**Unfixed bot** ([run](https://github.com/dionysuzx/EIPs/actions/runs/22679370709)): `statuschange` rule, posted "Requires 1 more reviewers from @mayushii-nyan", PR blocked.

**Fixed bot** ([run](https://github.com/dionysuzx/EIPs/actions/runs/22679426821)): `authors` rule with `pr_approval: true`, matched PR author, enabled auto-merge.