### PR TITLE
Label reviewer roles in bot comment

### DIFF
--- a/src/__tests__/reviewerComment.test.ts
+++ b/src/__tests__/reviewerComment.test.ts
@@ -8,6 +8,7 @@ describe("generateReviewerComment", () => {
         const filesToRules: { [key: string]: FileRuleCommentData[] } = {
             "EIPS/eip-1.md": [
                 {
+                    name: "editors",
                     min: 2,
                     requesting: ["lightclient", "samwilsn", "g11tech"],
                     mention_reviewers: false,
@@ -17,7 +18,7 @@ describe("generateReviewerComment", () => {
 
         const comment = generateReviewerComment(filesToRules);
         expect(comment).toContain(
-            "Requires 2 more reviewers from `@g11tech`, `@lightclient`, `@samwilsn`",
+            "Requires 2 more reviews from **Editors**: `@g11tech`, `@lightclient`, `@samwilsn`",
         );
     });
 
@@ -25,11 +26,13 @@ describe("generateReviewerComment", () => {
         const filesToRules: { [key: string]: FileRuleCommentData[] } = {
             "EIPS/eip-1.md": [
                 {
+                    name: "authors",
                     min: 1,
                     requesting: ["vitalik"],
                     mention_reviewers: true,
                 },
                 {
+                    name: "editors",
                     min: 2,
                     requesting: ["lightclient", "samwilsn", "g11tech"],
                     mention_reviewers: false,
@@ -38,9 +41,11 @@ describe("generateReviewerComment", () => {
         };
 
         const comment = generateReviewerComment(filesToRules);
-        expect(comment).toContain("Requires 1 more reviewers from @vitalik");
         expect(comment).toContain(
-            "Requires 2 more reviewers from `@g11tech`, `@lightclient`, `@samwilsn`",
+            "Requires 1 more review from **Authors**: @vitalik",
+        );
+        expect(comment).toContain(
+            "Requires 2 more reviews from **Editors**: `@g11tech`, `@lightclient`, `@samwilsn`",
         );
     });
 
@@ -48,11 +53,13 @@ describe("generateReviewerComment", () => {
         const filesToRules: { [key: string]: FileRuleCommentData[] } = {
             "EIPS/eip-1.md": [
                 {
+                    name: "authors",
                     min: 1,
                     requesting: ["samwilsn"],
                     mention_reviewers: true,
                 },
                 {
+                    name: "editors",
                     min: 2,
                     requesting: ["lightclient", "samwilsn", "g11tech"],
                     mention_reviewers: false,
@@ -61,21 +68,25 @@ describe("generateReviewerComment", () => {
         };
 
         const comment = generateReviewerComment(filesToRules);
-        expect(comment).toContain("Requires 1 more reviewers from @samwilsn");
         expect(comment).toContain(
-            "Requires 2 more reviewers from `@g11tech`, `@lightclient`, `@samwilsn`",
+            "Requires 1 more review from **Authors**: @samwilsn",
+        );
+        expect(comment).toContain(
+            "Requires 2 more reviews from **Editors**: `@g11tech`, `@lightclient`, `@samwilsn`",
         );
     });
 
-    it("dedupes rules with the same reviewers and keeps the first", () => {
+    it("dedupes rules with the same name and reviewers", () => {
         const filesToRules: { [key: string]: FileRuleCommentData[] } = {
             "EIPS/eip-1.md": [
                 {
+                    name: "editors",
                     min: 1,
                     requesting: ["bob", "alice"],
                     mention_reviewers: false,
                 },
                 {
+                    name: "editors",
                     min: 2,
                     requesting: ["alice", "bob"],
                     mention_reviewers: false,
@@ -86,8 +97,57 @@ describe("generateReviewerComment", () => {
         const comment = generateReviewerComment(filesToRules);
         expect(comment.match(/Requires/g)?.length).toBe(1);
         expect(comment).toContain(
-            "Requires 1 more reviewers from `@alice`, `@bob`",
+            "Requires 1 more review from **Editors**: `@alice`, `@bob`",
         );
+    });
+
+    it("dedupes editor rules with the same reviewers even when rule names differ", () => {
+        const filesToRules: { [key: string]: FileRuleCommentData[] } = {
+            "EIPS/eip-1.md": [
+                {
+                    name: "new",
+                    min: 1,
+                    requesting: ["samwilsn"],
+                    mention_reviewers: false,
+                },
+                {
+                    name: "statuschange",
+                    min: 1,
+                    requesting: ["samwilsn"],
+                    mention_reviewers: false,
+                },
+            ],
+        };
+
+        const comment = generateReviewerComment(filesToRules);
+        expect(comment.match(/Requires/g)?.length).toBe(1);
+        expect(comment).toContain(
+            "Requires 1 more review from **Editors**: `@samwilsn`",
+        );
+    });
+
+    it("keeps authors and editors separate even with the same reviewers", () => {
+        const filesToRules: { [key: string]: FileRuleCommentData[] } = {
+            "EIPS/eip-1.md": [
+                {
+                    name: "authors",
+                    min: 1,
+                    requesting: ["samwilsn"],
+                    mention_reviewers: true,
+                },
+                {
+                    name: "editors",
+                    min: 1,
+                    requesting: ["samwilsn"],
+                    mention_reviewers: false,
+                },
+            ],
+        };
+
+        const comment = generateReviewerComment(filesToRules);
+        expect(comment.match(/Requires/g)?.length).toBe(2);
+        expect(comment).toContain("**Authors**");
+        expect(comment).toContain("**Editors**");
     });
 
     it("does not mutate requesting reviewer arrays", () => {
@@ -95,6 +155,7 @@ describe("generateReviewerComment", () => {
         const filesToRules: { [key: string]: FileRuleCommentData[] } = {
             "EIPS/eip-1.md": [
                 {
+                    name: "editors",
                     min: 1,
                     requesting,
                     mention_reviewers: false,
@@ -110,11 +171,13 @@ describe("generateReviewerComment", () => {
         const filesToRules: { [key: string]: FileRuleCommentData[] } = {
             "EIPS/eip-1.md": [
                 {
+                    name: "authors",
                     min: 1,
                     requesting: ["samwilsn"],
                     mention_reviewers: false,
                 },
                 {
+                    name: "authors",
                     min: 1,
                     requesting: ["samwilsn"],
                     mention_reviewers: true,
@@ -124,7 +187,9 @@ describe("generateReviewerComment", () => {
 
         const comment = generateReviewerComment(filesToRules);
         expect(comment.match(/Requires/g)?.length).toBe(1);
-        expect(comment).toContain("Requires 1 more reviewers from @samwilsn");
+        expect(comment).toContain(
+            "Requires 1 more review from **Authors**: @samwilsn",
+        );
         expect(comment).not.toContain("`@samwilsn`");
     });
 });

--- a/src/action.ts
+++ b/src/action.ts
@@ -554,6 +554,7 @@ async function run() {
                     const file = rule.annotation.file;
                     filesToRules[file] = filesToRules[file] || [];
                     filesToRules[file].push({
+                        name: rule.name,
                         min: rule.min,
                         requesting: rule.reviewers,
                         mention_reviewers: rule.mention_reviewers ?? false,

--- a/src/reviewerComment.ts
+++ b/src/reviewerComment.ts
@@ -1,11 +1,20 @@
 export type FileRuleCommentData = {
+    name: string;
     min: number;
     requesting: string[];
     mention_reviewers: boolean;
 };
 
-function buildRuleKey(requesting: string[]): string {
-    return requesting.join(",");
+function getRuleRole(name: string): "authors" | "editors" {
+    return name === "authors" ? "authors" : "editors";
+}
+
+function buildRuleKey(role: string, requesting: string[]): string {
+    return `${role}:${requesting.join(",")}`;
+}
+
+function formatRoleName(role: "authors" | "editors"): string {
+    return role === "authors" ? "Authors" : "Editors";
 }
 
 function formatReviewer(username: string, mention_reviewers: boolean): string {
@@ -18,7 +27,8 @@ function summarizeRules(
     const byRule = new Map<string, FileRuleCommentData>();
     for (const rule of fileRules) {
         const requesting = [...rule.requesting].sort();
-        const key = buildRuleKey(requesting);
+        const role = getRuleRole(rule.name);
+        const key = buildRuleKey(role, requesting);
         const existing = byRule.get(key);
         if (existing) {
             existing.mention_reviewers =
@@ -26,6 +36,7 @@ function summarizeRules(
             continue;
         }
         byRule.set(key, {
+            name: role,
             min: rule.min,
             requesting,
             mention_reviewers: rule.mention_reviewers,
@@ -41,7 +52,7 @@ export function generateReviewerComment(
     for (const [file, rules] of Object.entries(filesToRules)) {
         comment = `${comment}\n\n### File \`${file}\`\n\n`;
         for (const rule of summarizeRules(rules)) {
-            comment = `${comment}Requires ${rule.min} more reviewers from ${rule.requesting
+            comment = `${comment}Requires ${rule.min} more ${rule.min === 1 ? "review" : "reviews"} from **${formatRoleName(getRuleRole(rule.name))}**: ${rule.requesting
                 .map((r) => formatReviewer(r, rule.mention_reviewers))
                 .join(", ")}\n`;
         }


### PR DESCRIPTION
## Summary
- Bot comments now distinguish between **Authors** and **Editors** so users can tell who needs to act
- Internal rule names (e.g. `new`, `statuschange`) are mapped to user-facing role labels
- Singular/plural grammar: "1 more review" vs "2 more reviews"

Closes #429